### PR TITLE
feat: add sdale watch command

### DIFF
--- a/sdale/cli.py
+++ b/sdale/cli.py
@@ -6,6 +6,7 @@ remote execution, and event logging.
 
 Usage:
     sdale connect <dale>
+    sdale watch <dale>
     sdale run <dale> "<command>"
     sdale output <dale> [--lines N]
     sdale sync <dale> <src> [dst]
@@ -27,6 +28,7 @@ from .config import DaleConfig, get_dale, list_dales, find_config_path
 from .logger import EventLogger
 from .remote import (
     rsync,
+    tmux_attach,
     tmux_capture,
     tmux_ensure,
     tmux_has_session,
@@ -65,7 +67,26 @@ def cmd_connect(args: argparse.Namespace) -> None:
 
     logger.log("dale_connect", tmux_session=dale.session, host=dale.host)
     info(f"tmux session '{dale.session}' ready")
-    info(f"Attach with: ssh {dale.ssh_dest} -t \"tmux attach -t {dale.session}\"")
+    info(f"Watch with: sdale watch {dale.name}  (Ctrl-b d to detach)")
+
+
+def cmd_watch(args: argparse.Namespace) -> None:
+    """Attach to a dale's tmux session to watch in real time.
+
+    Opens an interactive SSH session that attaches to the dale's tmux
+    session. You see exactly what the agent is doing. Ctrl-b d to detach.
+    """
+    dale = get_dale(args.dale)
+
+    if not tmux_has_session(dale):
+        err(f"No active session '{dale.session}' on {dale.name}. "
+            f"Run 'sdale connect {dale.name}' first.")
+        sys.exit(1)
+
+    info(f"Attaching to dale '{dale.name}' (session: {dale.session})")
+    print(f"  Detach with: Ctrl-b d")
+    print()
+    tmux_attach(dale)
 
 
 def cmd_run(args: argparse.Namespace) -> None:
@@ -270,6 +291,10 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("connect", help="Create/reuse tmux session on a dale")
     p.add_argument("dale", help="Dale name from sdale.json")
 
+    # watch
+    p = sub.add_parser("watch", help="Attach to the dale's tmux session (live view)")
+    p.add_argument("dale", help="Dale name from sdale.json")
+
     # run
     p = sub.add_parser("run", help="Send a command to the dale's tmux session")
     p.add_argument("dale", help="Dale name from sdale.json")
@@ -325,6 +350,7 @@ def main() -> None:
     # Map subcommands to functions
     commands = {
         "connect": cmd_connect,
+        "watch": cmd_watch,
         "run": cmd_run,
         "output": cmd_output,
         "sync": cmd_sync,

--- a/sdale/remote.py
+++ b/sdale/remote.py
@@ -4,6 +4,7 @@ Wraps SSH and rsync commands for interacting with dales.
 All remote commands go through tmux sessions for co-dev observability.
 """
 
+import os
 import subprocess
 
 from .config import DaleConfig
@@ -101,6 +102,31 @@ def tmux_capture(dale: DaleConfig, lines: int = 20) -> str:
         capture=True,
     )
     return result.stdout
+
+
+def tmux_attach(dale: DaleConfig) -> None:
+    """Attach to the dale's tmux session interactively.
+
+    This gives the user a live view of the tmux session where sdale
+    sends commands. The user sees everything in real time and can
+    even type (though the session is meant for observation).
+
+    Replaces the current process with an interactive SSH + tmux attach.
+
+    Args:
+        dale: The dale configuration.
+
+    Raises:
+        RuntimeError: If no tmux session exists on the dale.
+    """
+    if not tmux_has_session(dale):
+        raise RuntimeError(
+            f"No tmux session '{dale.session}' on {dale.name}. "
+            f"Run 'sdale connect {dale.name}' first."
+        )
+    cmd = ["ssh", *dale.ssh_args, "-t", dale.ssh_dest,
+           f"tmux attach -t '{dale.session}'"]
+    os.execvp("ssh", cmd)
 
 
 def tmux_kill(dale: DaleConfig) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,12 @@ class TestBuildParser(unittest.TestCase):
         self.assertEqual(args.subcmd, "connect")
         self.assertEqual(args.dale, "edge")
 
+    def test_watch_subcommand(self) -> None:
+        """'watch' subcommand parses dale name."""
+        args = self.parser.parse_args(["watch", "edge"])
+        self.assertEqual(args.subcmd, "watch")
+        self.assertEqual(args.dale, "edge")
+
     def test_run_subcommand(self) -> None:
         """'run' subcommand parses dale name and command."""
         args = self.parser.parse_args(["run", "edge", "docker build ."])

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -12,6 +12,7 @@ from unittest.mock import patch, call, MagicMock
 from sdale.config import DaleConfig
 from sdale.remote import (
     ssh,
+    tmux_attach,
     tmux_ensure,
     tmux_has_session,
     tmux_send,
@@ -173,6 +174,35 @@ class TestTmuxCapture(unittest.TestCase):
 
         cmd = mock_run.call_args[0][0][-1]
         self.assertIn("tail -50", cmd)
+
+
+class TestTmuxAttach(unittest.TestCase):
+    """Tests for tmux_attach — attaching to tmux sessions."""
+
+    @patch("sdale.remote.os.execvp")
+    @patch("sdale.remote.subprocess.run")
+    def test_attaches_to_session(self, mock_run: MagicMock, mock_exec: MagicMock) -> None:
+        """Calls execvp with the correct ssh + tmux attach command."""
+        mock_run.return_value = subprocess.CompletedProcess([], 0, stdout="")
+        dale = make_dale(session="work")
+
+        tmux_attach(dale)
+
+        mock_exec.assert_called_once()
+        cmd = mock_exec.call_args[0][1]
+        self.assertEqual(cmd[0], "ssh")
+        self.assertIn("-t", cmd)
+        self.assertIn("tmux attach -t 'work'", cmd[-1])
+
+    @patch("sdale.remote.subprocess.run")
+    def test_raises_when_no_session(self, mock_run: MagicMock) -> None:
+        """Raises RuntimeError when no tmux session exists."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "ssh")
+        dale = make_dale()
+
+        with self.assertRaises(RuntimeError) as ctx:
+            tmux_attach(dale, )
+        self.assertIn("No tmux session", str(ctx.exception))
 
 
 class TestTmuxKill(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Adds `sdale watch <dale>` command that attaches to the dale's tmux session for live observation of agent activity
- Updates `sdale connect` output to hint at `sdale watch` instead of raw ssh+tmux commands
- Uses `os.execvp` to replace the process with an interactive SSH session — clean attach/detach with `Ctrl-b d`

## Test plan
- [x] 75 tests passing (3 new: parser test, attach test, no-session error test)
- [ ] Manual: `sdale connect edge && sdale watch edge` — verify live tmux view
- [ ] Manual: `Ctrl-b d` detaches cleanly without killing session

🤖 Generated with [Claude Code](https://claude.com/claude-code)