### PR TITLE
feat: operator identity in sdale logs (#36)

### DIFF
--- a/sdale/logger.py
+++ b/sdale/logger.py
@@ -8,6 +8,7 @@ Events are scrubbed for secrets before writing.
 
 import json
 import os
+import subprocess
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -49,6 +50,35 @@ def _scrub_secrets(text: str) -> str:
     return text
 
 
+def detect_operator() -> str:
+    """Detect the current operator identity.
+
+    Resolution order:
+        1. ``$CLIDE_OPERATOR`` env var (set by boss when creating windows)
+        2. tmux window name (e.g. ``clem``, ``clide``)
+        3. ``"unknown"``
+
+    Returns:
+        The operator name string.
+    """
+    op = os.environ.get("CLIDE_OPERATOR", "").strip()
+    if op:
+        return op
+
+    try:
+        result = subprocess.run(
+            ["tmux", "display-message", "-p", "#{window_name}"],
+            capture_output=True, text=True, timeout=2,
+        )
+        name = result.stdout.strip()
+        if name and result.returncode == 0:
+            return name
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    return "unknown"
+
+
 class EventLogger:
     """JSONL event logger for a specific dale.
 
@@ -59,19 +89,22 @@ class EventLogger:
     Attributes:
         dale_name:  Name of the dale this logger is for.
         session_id: Unique session identifier (sdale-<dale>-<timestamp>).
+        operator:   Detected operator identity.
         log_file:   Path to the JSONL log file.
     """
 
     def __init__(self, dale_name: str) -> None:
         """Initialize the logger for a dale.
 
-        Creates the log directory if it doesn't exist.
+        Creates the log directory if it doesn't exist. Detects the
+        operator identity from env var or tmux window name.
 
         Args:
             dale_name: Name of the dale to log events for.
         """
         self.dale_name = dale_name
         self.session_id = f"sdale-{dale_name}-{int(time.time())}"
+        self.operator = detect_operator()
 
         log_dir = Path(
             os.environ.get("SDALE_LOG_DIR", Path.home() / ".sdale" / "logs")
@@ -97,6 +130,7 @@ class EventLogger:
             "session_id": self.session_id,
             "schema_version": 1,
             "dale": self.dale_name,
+            "operator": self.operator,
             **extra,
         }
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,13 +1,14 @@
-"""Tests for sdale.logger — JSONL event logging and secret scrubbing."""
+"""Tests for sdale.logger — JSONL event logging, secret scrubbing, operator detection."""
 
 import json
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
-from sdale.logger import EventLogger, _scrub_secrets
+from sdale.logger import EventLogger, _scrub_secrets, detect_operator
 
 
 class TestScrubSecrets(unittest.TestCase):
@@ -47,6 +48,35 @@ class TestScrubSecrets(unittest.TestCase):
             self.assertIn("[REDACTED:GH_TOKEN]", result)
             self.assertNotIn("sk-ant-secret", result)
             self.assertNotIn("ghp_tokentokentoken", result)
+
+
+class TestDetectOperator(unittest.TestCase):
+    """Tests for operator identity detection."""
+
+    @patch.dict(os.environ, {"CLIDE_OPERATOR": "clem"})
+    def test_env_var_takes_priority(self) -> None:
+        """CLIDE_OPERATOR env var is used first."""
+        self.assertEqual(detect_operator(), "clem")
+
+    @patch.dict(os.environ, {"CLIDE_OPERATOR": ""})
+    @patch("sdale.logger.subprocess.run")
+    def test_falls_back_to_tmux(self, mock_run: MagicMock) -> None:
+        """Falls back to tmux window name when env var is empty."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            [], 0, stdout="clide\n"
+        )
+        self.assertEqual(detect_operator(), "clide")
+
+    @patch.dict(os.environ, {"CLIDE_OPERATOR": ""})
+    @patch("sdale.logger.subprocess.run", side_effect=FileNotFoundError)
+    def test_unknown_when_no_tmux(self, mock_run: MagicMock) -> None:
+        """Returns 'unknown' when tmux is not available."""
+        self.assertEqual(detect_operator(), "unknown")
+
+    @patch.dict(os.environ, {"CLIDE_OPERATOR": "  hale  "})
+    def test_env_var_stripped(self) -> None:
+        """CLIDE_OPERATOR is stripped of whitespace."""
+        self.assertEqual(detect_operator(), "hale")
 
 
 class TestEventLogger(unittest.TestCase):
@@ -146,6 +176,17 @@ class TestEventLogger(unittest.TestCase):
                 result = EventLogger.get_log_path("edge")
                 self.assertIsNotNone(result)
                 self.assertTrue(result.is_file())
+
+    @patch("sdale.logger.detect_operator", return_value="clide")
+    def test_operator_field_in_events(self, mock_op: MagicMock) -> None:
+        """Every logged event includes the operator field."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"SDALE_LOG_DIR": tmpdir}):
+                logger = EventLogger("edge")
+                logger.log("dale_exec", command="ls")
+
+                event = json.loads(logger.log_file.read_text().strip())
+                self.assertEqual(event["operator"], "clide")
 
     def test_get_log_path_missing(self) -> None:
         """get_log_path returns None when no logs exist."""


### PR DESCRIPTION
Every JSONL event now includes operator field. Detects from CLIDE_OPERATOR env var > tmux window name > unknown. 5 new tests, 17 logger tests total.